### PR TITLE
Map short-description to VIVO.abstract

### DIFF
--- a/app/works.py
+++ b/app/works.py
@@ -38,6 +38,9 @@ def crosswalk_works(orcid_profile, person_uri, graph):
 
         work_uri = ns.D[to_hash_identifier(PREFIX_DOCUMENT, (title, work_type))]
 
+        #Abstract
+        abstract = work["short-description"]
+
         #Publication date
         (publication_year, publication_month, publication_day) = _get_crossref_publication_date(crossref_record) \
             or _get_publication_date(work)
@@ -91,6 +94,8 @@ def crosswalk_works(orcid_profile, person_uri, graph):
                     graph.add((authorship_uri, RDF.type, VIVO.Authorship))
                     graph.add((authorship_uri, VIVO.relates, work_uri))
                     graph.add((authorship_uri, VIVO.relates, author_uri))
+        #Abstract
+        graph.add((work_uri, VIVO.abstract, Literal(abstract)))
 
         #Date
         date_uri = work_uri + "-date"


### PR DESCRIPTION
### Covers:

The short description in the orcid profile should be mapped to an abstract.
### Related Issue:

https://github.com/gwu-libraries/orcid2vivo/issues/12
### Sample output

```
$ python orcid2vivo.py 0000-0003-1527-0030
...
d:doc-f146de625ad3838aa1de5151e8e534cb a bibo:AcademicArticle ;
    rdfs:label "A set of transfer-related services" ;
    bibo:issue "1-2" ;
    bibo:volume "15" ;
    vivo:abstract "None" ;
    vivo:dateTimeValue d:doc-f146de625ad3838aa1de5151e8e534cb-date ;
    vivo:hasPublicationVenue d:jrnl-1e6a499106514eca0defc7679a9128bd .
...
```
